### PR TITLE
Added extened measurments to the voidbranchstopper, which should neve…

### DIFF
--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilterExtensions.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilterExtensions.hpp
@@ -92,7 +92,10 @@ struct CombinatorialKalmanFilterExtensions {
   /// Default branch stopper which will never stop
   /// @return false
   static BranchStopperResult voidBranchStopper(
-      const TrackProxy& /*track*/, const TrackStateProxy& /*trackState*/) {
+      const TrackProxy& track, const TrackStateProxy& trackState) {
+    if (track.nMeasurements() >= track.maxMeasurements()) {
+      return BranchStopperResult::StopAndKeep;
+    }
     return BranchStopperResult::Continue;
   }
 };


### PR DESCRIPTION
…r be really used

PLEASE DESCRIBE YOUR CHANGES.
THIS MESSAGE ENDS UP AS THE COMMIT MESSAGE.
DO NOT USE @-MENTIONS HERE!

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
